### PR TITLE
Aggiorna il README alla versione 11.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
-## Traduzione compatibile con l'unofficial patch versione: 10.7. 
+## Traduzione compatibile con l'unofficial patch versione: 11.5. 
 
 ### Stato traduzione: quasi completa. Le seguenti problematiche non influiscono sulla giocabilità.
 #### Problematiche di cui siamo a conoscenza:
 - Traduzioni mancanti: qualche NPC minore e qualche frase sfuggita. Segnalatele e verranno corrette.
 - Audio nei dialoghi mancante se si impersona un personaggio femminile: si conosce già la soluzione al problema, serve solo del tempo per applicarla. In ogni caso il dialogo funziona comunque.
-
-### Concluso il lavoro (devo ancora valutare se compreso il contenuto plus o meno) si procederà assicurando la compatibilità con le versioni successive: 10.8/10.9/11.0
 ---
 ### La traduzione di Vampire The Masquerade esisteva già, ma è compatibile con la versione 9.5 della unofficial patch e non con le successive visto che comporta le seguenti problematiche:
 #### Quest mancanti | Condizioni per le quest mancanti o sbagliate | Menù disordinati
@@ -15,16 +13,16 @@
 ---
 ### Collaboratori: Katerine73(Root78), crazyLillo e NarakuITA
 
-### Ogni suggerimento e feedback è ben accetto. https://github.com/tesivo/tesivo_s_VTMB_italian_translation_for_Unofficial_Patch/issues
+### Ogni suggerimento e feedback è ben accetto. https://github.com/tesivo/VTMB_italian_translation_for_Unofficial_Patch/issues
 ### Chiunque volesse collaborare mi contatti.
 
 ### Ringrazio gli sviluppatori di Vampire The Masquerade, gli autori della Unofficial Patch e gli autori della traduzione versione 9.5.
 ---
 ## Installazione:
-- Installate l'unofficial patch 10.7, per esempio, da qui: 
-https://www.patches-scrolls.de/patch/4647/7/75293/download
+- Installate l'unofficial patch 11.5, per esempio, da qui: 
+[LINK DA AGGIORNARE]
 - Copiate e sovrascrivete i file dell'archivio nel link qui sotto in Vampire The Masquerade - Bloodlines\Unofficial_Patch:
-https://github.com/tesivo/tesivo_s_VTMB_italian_translation_for_Unofficial_Patch/archive/master.zip
+https://github.com/tesivo/VTMB_italian_translation_for_Unofficial_Patch/archive/master.zip
 
 ### Avviate Vampire The Masquerade: Bloodline dal collegamento sul desktop, oppure, se volete avviarlo da Steam, dovete andare su proprietà e opzioni di avvio del gioco ed inserire la seguente riga di comando:
 ### -game Unofficial_Patch

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ---
 ## Installazione:
 - Installate l'unofficial patch 11.5, per esempio, da qui: 
-[LINK DA AGGIORNARE]
+https://www.patches-scrolls.de/patch/4647/7/75432/download
 - Copiate e sovrascrivete i file dell'archivio nel link qui sotto in Vampire The Masquerade - Bloodlines\Unofficial_Patch:
 https://github.com/tesivo/VTMB_italian_translation_for_Unofficial_Patch/archive/master.zip
 


### PR DESCRIPTION
## Riepilogo
- Aggiorna il numero di versione compatibile della patch da 10.7 a 11.5
- Rimuove la nota superata sul lavoro futuro (10.8/10.9/11.0), ormai completato
- Corregge i link che puntavano al vecchio nome del repository
- Aggiorna il link di download della patch 11.5
